### PR TITLE
Patcher for the latest GitKraken (since 7.7.0) [PRO]

### DIFF
--- a/GitCracken/patches/pro.diff
+++ b/GitCracken/patches/pro.diff
@@ -1,30 +1,32 @@
---- src/render/static/entryPoints/main/index.js
-+++ src/render/static/entryPoints/main/index.js
-@@ -2,7 +2,27 @@
- // instead, you want to edit src/js/main.jsx instead
+--- src/main/static/startMainProcess.js
++++ src/main/static/startMainProcess.js
+@@ -1,4 +1,21 @@
  /* eslint-disable no-console */
-
-+function PatchSnapshot() {
-+  const edmLiteD = snapshotResult.customRequire('@axosoft/edm-lite-d/src/d.js');
-+  snapshotResult.customRequire.cache['@axosoft/edm-lite-d/src/d.js'] = {
-+    exports: function() {
-+      let response = JSON.parse(edmLiteD(...arguments).toString('utf8'));
-+      if ('licenseExpiresAt' in response || 'licensedFeatures' in response) {
-+        response = {
-+          ...response,
-+          availableTrialDays: null,
-+          licenseExpiresAt: 8640000000000000,
-+          licensedFeatures: ['pro']
-+        };
-+      }
-+      return Buffer.from(JSON.stringify(response), 'utf8');
++
++function patchSnapshot() {
++  var RegistrationHelpers = snapshotResult.customRequire('./src/sharedModules/registration/shared/RegistrationHelpers.js');
++  var { decodeBody } = RegistrationHelpers;
++  RegistrationHelpers.decodeBody = (isNormalClient, modePrefixString, body) => {
++    var result = decodeBody(isNormalClient, modePrefixString, body);
++    console.log(result);
++    result = {
++      ...result,
++      licensedFeatures: ['pro'],
++      proAccessState: {}
 +    }
-+  };
++    console.log(result);
++    return result;
++  }
 +}
 +
  (function() {
-+  PatchSnapshot();
-+
-   const Perf = snapshotResult.customRequire('./src/js/utils/Performance.js');
-   Perf.timeEnd('loading monaco scripts');
-   Perf.time('index.js pre-bootstrap');
+   require('../../sharedModules/static/loadSnapshot');
+   if (process.env.GITKRAKEN_RUN_MAIN_TESTS) {
+@@ -27,6 +44,7 @@
+   global.mode = buildMode;
+ 
+   if (typeof snapshotResult !== 'undefined') {
++    patchSnapshot();
+     const path = require('path');
+     snapshotResult.setGlobals(global, process, global, {}, console, require, path.resolve());
+     snapshotResult.customRequire('./src/main/main.js');

--- a/GitCracken/patches/pro.diff
+++ b/GitCracken/patches/pro.diff
@@ -18,9 +18,9 @@
 +}
 +
  (function() {
-   require('../../sharedModules/static/loadSnapshot');
-   if (process.env.GITKRAKEN_RUN_MAIN_TESTS) {
-@@ -27,6 +42,7 @@
+   if (process.env.GITKRAKEN_OPEN_MAIN_DEV_TOOLS) {
+     require('./startDevTools');
+@@ -32,6 +47,7 @@
    global.mode = buildMode;
  
    if (typeof snapshotResult !== 'undefined') {

--- a/GitCracken/patches/pro.diff
+++ b/GitCracken/patches/pro.diff
@@ -1,6 +1,6 @@
 --- src/main/static/startMainProcess.js
 +++ src/main/static/startMainProcess.js
-@@ -1,4 +1,21 @@
+@@ -1,4 +1,19 @@
  /* eslint-disable no-console */
 +
 +function patchSnapshot() {
@@ -8,13 +8,11 @@
 +  var { decodeBody } = RegistrationHelpers;
 +  RegistrationHelpers.decodeBody = (isNormalClient, modePrefixString, body) => {
 +    var result = decodeBody(isNormalClient, modePrefixString, body);
-+    console.log(result);
 +    result = {
 +      ...result,
 +      licensedFeatures: ['pro'],
 +      proAccessState: {}
 +    }
-+    console.log(result);
 +    return result;
 +  }
 +}
@@ -22,7 +20,7 @@
  (function() {
    require('../../sharedModules/static/loadSnapshot');
    if (process.env.GITKRAKEN_RUN_MAIN_TESTS) {
-@@ -27,6 +44,7 @@
+@@ -27,6 +42,7 @@
    global.mode = buildMode;
  
    if (typeof snapshotResult !== 'undefined') {

--- a/GitCracken/patches/pro.diff
+++ b/GitCracken/patches/pro.diff
@@ -6,14 +6,14 @@
 +function patchSnapshot() {
 +  var RegistrationHelpers = snapshotResult.customRequire('./src/sharedModules/registration/shared/RegistrationHelpers.js');
 +  var { decodeBody } = RegistrationHelpers;
-+  RegistrationHelpers.decodeBody = (isNormalClient, modePrefixString, body) => {
-+    var result = decodeBody(isNormalClient, modePrefixString, body);
-+    result = {
-+      ...result,
++  RegistrationHelpers.decodeBody = function() {
++    var body = decodeBody(...arguments);
++    body = {
++      ...body,
 +      licensedFeatures: ['pro'],
 +      proAccessState: {}
 +    }
-+    return result;
++    return body;
 +  }
 +}
 +

--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@ GitKraken utils for non-commercial use
 
 Working on `GNU/Linux` (without `snap`), `Windows` and `macOS`.
 
-Author: KillWolfVlad at [GitKraken-AUR](https://github.com/KillWolfVlad/GitKraken-AUR)
+Author: PMExtra, forked from KillWolfVlad at [GitKraken-AUR](https://github.com/KillWolfVlad/GitKraken-AUR)
 
-> WARNING! On `macOS` you should patch `GitKraken` only after first launch and full program closing!
+✔ Verified with GitKraken v7.7.0 ~ v8.1.1
+
+It should support any newer version of GitKraken, unless the entrypoint code (`src/main/static/startMainProcess.js` of GitKraken source) is modified.
 
 ## Requirements
 
@@ -14,19 +16,41 @@ Author: KillWolfVlad at [GitKraken-AUR](https://github.com/KillWolfVlad/GitKrake
 
 ## Quick start
 
-- `git clone https://github.com/5cr1pt/GitCracken.git`
+- `git clone https://github.com/PMExtra/GitCracken.git`
 - `cd GitCracken/GitCracken/`
 - `yarn install`
 - `yarn build`
-- `node dist/bin/gitcracken.js patcher`
+- `yarn gitcracken patcher`
 
-## Disable Automatic Update
+## Notice
 
-Add this content to your `hosts` file:
+### It need to refresh the GitKraken account information after this patch
+
+This patch will modify your license while GitKraken fetching your profile. So if you still got free edition, you should re-login your GitKraken account.
+
+Please ensure the communication with GitKraken server. Somebody may blocked the GitKraken server by the DNS or hosts file, please comment out or remove it temporarily.
+
+If you still got free edition after re-login. Deleting the local profile might help. (Usually the path is `%appdata%\.gitkraken` for Windows, or `~/.gitkraken` for Linux or macOS)
+
+### On macOS you should patch GitKraken after first launch.
+
+There is a quarantine flag while downloading an App from Internet. If you changed it before the first launch, macOS will think the App was broken.
+
+If you already do that, you can execute `sudo xattr -rd com.apple.quarantine /Application/GitKraken.app` to remove quarantine flag.
+
+Search `macos quarantine` for more details.
+
+### This patch only works with GitKraken 7.7.0 and later
+
+If you really want to use an older version, you can ref the commit [`011e42e`](https://github.com/PMExtra/GitCracken/commit/011e42ee8f203b30e4fd606ac47af88293fbbf10) for 7.6.x.
+For more older version, you can use the original patcher from [5cr1pt/GitKraken](https://github.com/5cr1pt/GitCracken/commit/192c695e0e850676a3c014295636b46471887477).
+
+### Disable Automatic Update
+
+The patch will be overwrite after each GitKraken update. So you should patch again after each update.
+
+If you don't want any update, you can block the update server. Just add this content to your `hosts` file:
 
 ```text
 0.0.0.0 release.gitkraken.com
 ```
-
-Check [GitCracken/README.md](https://github.com/5cr1pt/GitCracken/blob/master/GitCracken/README.md) for more usage information.
-


### PR DESCRIPTION
Pro features patch for v7.7.0+.

This patch will support any newer version of GitKraken, unless the entrypoint code (`src/main/static/startMainProcess.js` of GitKraken source) is updated.

✔ Verified with GitKraken v7.7.0 ~ v8.1.1

# Notice

## It need to refresh the GitKraken account information after this patch

This patch will modify your license while GitKraken fetching your profile. So if you still got free edition, you should re-login your GitKraken account.

Please ensure the communication with GitKraken server. Somebody may blocked the GitKraken server by the DNS or hosts file, please comment out or remove it temporarily.

If you still got free edition after re-login. Deleting the local profile might help. (Usually the path is `%appdata%\.gitkraken` for Windows, or `~/.gitkraken` for Linux or macOS)

## Ensure you got the latest patcher

There are some people they used the old patcher instead of mine, then feedback the patcher doesn't work here.😒

Please ensure you checked out the patcher from my repo (https://github.com/PMExtra/GitCracken), the latest commit hash is https://github.com/5cr1pt/GitCracken/commit/07f422731c3bd488ed74872420ad5c034aa71bb4 (`07f422731c3bd488ed74872420ad5c034aa71bb4`). You can check it through `git rev-parse HEAD` command.

## This patch only works with GitKraken 7.7.0 and later

If you really want to use an older version, you can ref the commit 011e42ee8f203b30e4fd606ac47af88293fbbf10 for 7.6.x.
For more older version, you can use the original patcher from @5cr1pt. (8a35197c76f3ead5390ccb2055258692d22aba15).